### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverage
 docs/build
 notebooks
 build/
+linux_scripts/
+ckpts/

--- a/eztorch/datasets/soccernet.py
+++ b/eztorch/datasets/soccernet.py
@@ -405,6 +405,7 @@ class SoccerNet(Dataset):
             precompute_labels = True
 
             cache_dir = self._label_args.pop("cache_dir", None)
+            cache_dir = None if cache_dir == "" else cache_dir
             if cache_dir is not None:
                 cache_dir = Path(cache_dir)
                 labels_file = cache_dir / "labels.pt"
@@ -577,7 +578,7 @@ def _get_labels(
         for label in range(num_labels):
             if label in timestamp_label_annotations:
                 labels[label, idx_timestamp] = 1
-        return labels.permute(1, 0)
+    return labels.permute(1, 0)
 
 
 class ImageSoccerNet(SoccerNet):

--- a/eztorch/datasets/soccernet_utils/soccernet_paths.py
+++ b/eztorch/datasets/soccernet_utils/soccernet_paths.py
@@ -121,7 +121,7 @@ class SoccerNetPaths:
         """Serialize annotations for the dataset."""
         self._video_paths = np.array(
             [match_content["UrlLocal"] for match_content in self._annotations]
-        ).astype(np.string_)
+        ).astype(np.bytes_)
         self._halves_per_video = torch.tensor(
             [len(match_content["halves"]) for match_content in self._annotations],
             dtype=torch.uint8,
@@ -132,7 +132,7 @@ class SoccerNetPaths:
                 for match_content in self._annotations
                 for _, half_content in match_content["halves"].items()
             ]
-        ).astype(np.string_)
+        ).astype(np.bytes_)
 
         self._half_ids = torch.tensor(
             [


### PR DESCRIPTION
Minor fixes made to `soccernet.py` `cache_dir` argument check for empty string and moving the return of labels inside of the  `get_labels()` function outside of the for loop. 

Minor fix in `soccernet_paths.py` for deprecated `.astype(np.string_)` function, changing it to `.astype(np.bytes_)`

